### PR TITLE
feat: Added Item Market Section with Search Bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.1.2](https://github.com/Syrup/cybertorn-terminal/compare/v1.1.1...v1.1.2) (2026-03-11)
+
+
+### Bug Fixes
+
+* resolve React error [#31](https://github.com/Syrup/cybertorn-terminal/issues/31) in FactionInfo and improve API input UX ([e475710](https://github.com/Syrup/cybertorn-terminal/commit/e47571036109ff227a696dc0120fb908bc3e55b0))
+
 ### [1.1.1](https://github.com/Syrup/cybertorn-terminal/compare/v1.1.0...v1.1.1) (2026-03-09)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cybertorn-terminal",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A sleek, easy-to-use dashboard to track your Torn City progress. Built by a player, for the players.",
   "private": true,
   "scripts": {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { Equipment } from "@/components/sections/Equipment";
 import { FactionInfo } from "@/components/sections/FactionInfo";
 import { AttacksCrimes } from "@/components/sections/AttacksCrimes";
 import { MarketSection } from "@/components/sections/MarketSection";
+import { ItemMarketSection } from "@/components/sections/ItemMarketSection";
 import { StocksProperties } from "@/components/sections/StocksProperties";
 import { SkillsEducation } from "@/components/sections/SkillsEducation";
 import { EventsNotifications } from "@/components/sections/EventsNotifications";
@@ -124,6 +125,9 @@ export default function Home() {
                 </div>
                 <div id="education">
                   <SkillsEducation />
+                </div>
+                <div id="market">
+                  <ItemMarketSection />
                 </div>
               </section>
 

--- a/src/components/ApiKeyInput.tsx
+++ b/src/components/ApiKeyInput.tsx
@@ -24,6 +24,11 @@ export function ApiKeyInput() {
           type="password"
           value={inputKey ?? apiKey}
           onChange={(e) => setInputKey(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !isLoading && (inputKey ?? apiKey)) {
+              handleSave();
+            }
+          }}
           placeholder="API KEY"
           className="h-9 w-full sm:w-48 bg-muted border border-border pl-9 pr-3 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50 uppercase"
         />

--- a/src/components/sections/FactionInfo.tsx
+++ b/src/components/sections/FactionInfo.tsx
@@ -16,7 +16,7 @@ interface FactionData {
   respect: number;
   age: number;
   capacity: number;
-  members: number;
+  members: number | Record<string, unknown>;
   best_chain: number;
   territory: Record<string, unknown>;
   chain: {
@@ -82,7 +82,7 @@ export function FactionInfo() {
 
         <div className="grid grid-cols-2 gap-2">
            <StatBlock label="Respect" value={faction.respect.toLocaleString()} />
-           <StatBlock label="Members" value={faction.members} />
+           <StatBlock label="Members" value={(faction.members && typeof faction.members === "object") ? Object.keys(faction.members).length : (faction.members || 0)} />
            <StatBlock label="Territory" value={Object.keys(faction.territory || {}).length} />
            <StatBlock label="Chain" value={chain?.current || 0} />
         </div>

--- a/src/components/sections/ItemMarketSection.tsx
+++ b/src/components/sections/ItemMarketSection.tsx
@@ -72,11 +72,10 @@ export function ItemMarketSection() {
 
   const listings: ItemListingEntry[] = Object.entries(itemData)
     .map(([id, listing]) => ({ id, ...listing }))
-    .filter(item => item.name.toLocaleLowerCase().includes(value.toLocaleLowerCase()))
-    .sort((a, b) => a.market_value - b.market_value)
-    .slice(0, 10);
-
-    console.log(listings);
+    .filter(item => item.circulation > 0 && item.market_value > 0) // filters out invalid items (no market value / no circulation)
+    .filter(item => item.name.toLocaleLowerCase().includes(value.toLocaleLowerCase())) // filters items by search (search = cd -> shows [mix cd, cd player, etc.])
+    .sort((a, b) => a.market_value - b.market_value) // sorts by lowest market_value
+    .slice(0, 10); // lists up to 10
 
   return (
     <Card title="Items Market" icon={ShoppingBag} className="h-full flex flex-col">
@@ -101,8 +100,8 @@ export function ItemMarketSection() {
           {listings.map((listing) => (
             <tr key={listing.id} className="border-b border-border/50 last:border-0 hover:bg-muted/20">
               <td className="p-2 font-bold tabular-nums text-green-500">{listing.name}</td>
-              <td className="p-2 text-right tabular-nums">{listing.circulation}</td>
-              <td className="p-2 text-right tabular-nums text-muted-foreground">${listing.market_value}</td>
+              <td className="p-2 text-right tabular-nums">{listing.circulation.toLocaleString()}</td>
+              <td className="p-2 text-right tabular-nums text-muted-foreground">${listing.market_value.toLocaleString()}</td>
             </tr>
           ))}
           </tbody>

--- a/src/components/sections/ItemMarketSection.tsx
+++ b/src/components/sections/ItemMarketSection.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useTorn } from "@/lib/torn-context";
+import { Card } from "@/components/ui/Card";
+import { ShoppingBag } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface ItemListing {
+  name: string;
+  market_value: number;
+  circulation: number;
+}
+
+interface ItemListingEntry extends ItemListing {
+  id: string;
+}
+
+export function ItemMarketSection() {
+  const { apiKey, fetchSection } = useTorn();
+  const [ itemData, setItemData ] = useState<Record<string, ItemListing> | null>(null);
+  const [ loading, setLoading ] = useState(false);
+  const [ value, setValue ] = useState<string>('');
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.currentTarget.value);
+  }
+
+  useEffect(() => {
+    if (!apiKey) return;
+    let active = true;
+
+    const loadMarket = async () => {
+      setLoading(true);
+      try {
+        const res = await fetchSection((client) => client.getTornItems());
+        if (res?.data && active) {
+          const d = res.data as Record<string, unknown>;
+          if (d.items) {
+            setItemData(d.items as Record<string, ItemListing>);
+          }
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    void loadMarket();
+    return () => {
+      active = false;
+    };
+  }, [apiKey, fetchSection]);
+
+  if (loading && !itemData) {
+    return (
+      <Card title="Items Market" icon={ShoppingBag} className="min-h-[200px]">
+        <div className="p-4 text-muted-foreground text-sm font-mono animate-pulse">
+          LOADING MARKET DATA...
+        </div>
+      </Card>
+    );
+  }
+
+  if (!itemData) {
+    return (
+      <Card title="Items Market" icon={ShoppingBag} className="min-h-[200px]">
+        <div className="p-4 text-muted-foreground text-sm font-mono">
+          NO DATA LOADED
+        </div>
+      </Card>
+    );
+  }
+
+  const listings: ItemListingEntry[] = Object.entries(itemData)
+    .map(([id, listing]) => ({ id, ...listing }))
+    .filter(item => item.name.toLocaleLowerCase().includes(value.toLocaleLowerCase()))
+    .sort((a, b) => a.market_value - b.market_value)
+    .slice(0, 10);
+
+    console.log(listings);
+
+  return (
+    <Card title="Items Market" icon={ShoppingBag} className="h-full flex flex-col">
+      <div className="p-4 border-b border-border">
+        <div className="flex justify-between items-end">
+          <div className="text-xs text-muted-foreground uppercase font-mono">
+            <input type="text" placeholder="Search Items..." value={value} onChange={handleChange} className="outline-0"></input>
+          </div>
+        </div>
+      </div>
+      
+      <div className="flex-1 overflow-y-auto max-h-[250px] p-0">
+        <table className="w-full text-left text-xs font-mono">
+          <thead className="bg-muted/30 sticky top-0 backdrop-blur-sm">
+            <tr>
+              <th className="p-2 font-normal text-muted-foreground">NAME</th>
+              <th className="p-2 font-normal text-muted-foreground text-right">CIRCULATION</th>
+              <th className="p-2 font-normal text-muted-foreground text-right">VALUE</th>
+            </tr>
+          </thead>
+          <tbody>
+          {listings.map((listing) => (
+            <tr key={listing.id} className="border-b border-border/50 last:border-0 hover:bg-muted/20">
+              <td className="p-2 font-bold tabular-nums text-green-500">{listing.name}</td>
+              <td className="p-2 text-right tabular-nums">{listing.circulation}</td>
+              <td className="p-2 text-right tabular-nums text-muted-foreground">${listing.market_value}</td>
+            </tr>
+          ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
Created a section for the Item Market with a search, showing up to 10 items, each listing showing its name, circulation, and market value. Items are sorted by lowest price first. The case doesn't have to match as well.

Default (no search value):
<img width="471" height="353" alt="image" src="https://github.com/user-attachments/assets/2461ca98-f75a-483a-b9e6-21dce7def698" />

Example search:
<img width="470" height="352" alt="image" src="https://github.com/user-attachments/assets/1348c5a7-2f2e-44cc-9ce1-f6960fefa7aa" />

**Possible Changes**

- List Random 10 for default or most popular
- Chaching
- Check item to keep in list with search not effecting it
- Dropdown for each item showing more information
- Sorts for each column (ascending, descending)