### PR TITLE
fix: resolve faction members rendering crash (closes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.1.2](https://github.com/Syrup/cybertorn-terminal/compare/v1.1.1...v1.1.2) (2026-03-11)
+
+
+### Bug Fixes
+
+* resolve React error [#31](https://github.com/Syrup/cybertorn-terminal/issues/31) in FactionInfo and improve API input UX ([e475710](https://github.com/Syrup/cybertorn-terminal/commit/e47571036109ff227a696dc0120fb908bc3e55b0))
+
 ### [1.1.1](https://github.com/Syrup/cybertorn-terminal/compare/v1.1.0...v1.1.1) (2026-03-09)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cybertorn-terminal",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A sleek, easy-to-use dashboard to track your Torn City progress. Built by a player, for the players.",
   "private": true,
   "scripts": {

--- a/src/components/ApiKeyInput.tsx
+++ b/src/components/ApiKeyInput.tsx
@@ -24,6 +24,11 @@ export function ApiKeyInput() {
           type="password"
           value={inputKey ?? apiKey}
           onChange={(e) => setInputKey(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !isLoading && (inputKey ?? apiKey)) {
+              handleSave();
+            }
+          }}
           placeholder="API KEY"
           className="h-9 w-full sm:w-48 bg-muted border border-border pl-9 pr-3 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50 uppercase"
         />

--- a/src/components/sections/FactionInfo.tsx
+++ b/src/components/sections/FactionInfo.tsx
@@ -16,7 +16,7 @@ interface FactionData {
   respect: number;
   age: number;
   capacity: number;
-  members: number;
+  members: number | Record<string, unknown>;
   best_chain: number;
   territory: Record<string, unknown>;
   chain: {
@@ -82,7 +82,7 @@ export function FactionInfo() {
 
         <div className="grid grid-cols-2 gap-2">
            <StatBlock label="Respect" value={faction.respect.toLocaleString()} />
-           <StatBlock label="Members" value={faction.members} />
+           <StatBlock label="Members" value={(faction.members && typeof faction.members === "object") ? Object.keys(faction.members).length : (faction.members || 0)} />
            <StatBlock label="Territory" value={Object.keys(faction.territory || {}).length} />
            <StatBlock label="Chain" value={chain?.current || 0} />
         </div>


### PR DESCRIPTION
This PR fixes the 'Minified React error #31' caused by the Torn API returning faction members as an object instead of a number. It also adds Enter key support to the API key input field for better UX.